### PR TITLE
ctypes workaround

### DIFF
--- a/from_cpython/Include/Python.h
+++ b/from_cpython/Include/Python.h
@@ -116,6 +116,9 @@ PyAPI_FUNC(PyObject*) PyObject_GetHcAttrString(PyObject*, const char*) PYSTON_NO
 PyAPI_FUNC(int) PyObject_SetHcAttrString(PyObject*, const char*, PyObject*) PYSTON_NOEXCEPT;
 PyAPI_FUNC(int) PyObject_DelHcAttrString(PyObject*, const char*) PYSTON_NOEXCEPT;
 
+// Workaround: call this instead of setting tp_dict.
+PyAPI_FUNC(void) PyType_SetDict(PyTypeObject*, PyObject*) PYSTON_NOEXCEPT;
+
 #include "codecs.h"
 #include "pyerrors.h"
 

--- a/from_cpython/Modules/_ctypes/_ctypes.c
+++ b/from_cpython/Modules/_ctypes/_ctypes.c
@@ -425,7 +425,9 @@ StructUnionType_new(PyTypeObject *type, PyObject *args, PyObject *kwds, int isSt
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)dict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)dict;
+    PyType_SetDict(result, dict);
     dict->format = _ctypes_alloc_format_string(NULL, "B");
     if (dict->format == NULL) {
         Py_DECREF(result);
@@ -995,7 +997,9 @@ PyCPointerType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)stgdict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)stgdict;
+    PyType_SetDict(result, stgdict);
 
     return (PyObject *)result;
 }
@@ -1461,7 +1465,9 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)stgdict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)stgdict;
+    PyType_SetDict(result, stgdict);
 
     /* Special case for character arrays.
        A permanent annoyance: char arrays are also strings!
@@ -1885,7 +1891,9 @@ static PyObject *CreateSwappedType(PyTypeObject *type, PyObject *args, PyObject 
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)stgdict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)stgdict;
+    PyType_SetDict(result, stgdict);
 
     return (PyObject *)result;
 }
@@ -2014,7 +2022,9 @@ PyCSimpleType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)stgdict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)stgdict;
+    PyType_SetDict(result, stgdict);
 
     /* Install from_param class methods in ctypes base classes.
        Overrides the PyCSimpleType_from_param generic method.
@@ -2394,7 +2404,9 @@ PyCFuncPtrType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     Py_DECREF(result->tp_dict);
-    result->tp_dict = (PyObject *)stgdict;
+    // Pyston change:
+    //result->tp_dict = (PyObject *)stgdict;
+    PyType_SetDict(result, stgdict);
 
     if (-1 == make_funcptrtype_dict(stgdict)) {
         Py_DECREF(result);

--- a/src/runtime/objmodel.cpp
+++ b/src/runtime/objmodel.cpp
@@ -972,26 +972,33 @@ Box* typeLookup(BoxedClass* cls, BoxedString* attr, GetattrRewriteArgs* rewrite_
         obj_saved->addAttrGuard(offsetof(BoxedClass, tp_mro), (intptr_t)mro);
 
         for (auto base : *mro) {
-            rewrite_args->out_success = false;
-            if (base == cls) {
-                // Small optimization: don't have to load the class again since it was given to us in
-                // a register.
-                assert(rewrite_args->obj == obj_saved);
-            } else {
-                rewrite_args->obj = rewrite_args->rewriter->loadConst((intptr_t)base, Location::any());
-                // We are passing a constant object, and objects are not allowed to change shape
-                // (at least the kind of "shape" that Box::getattr is referring to)
-                rewrite_args->obj_shape_guarded = true;
+            if (rewrite_args) {
+                rewrite_args->out_success = false;
+                if (base == cls) {
+                    // Small optimization: don't have to load the class again since it was given to us in
+                    // a register.
+                    assert(rewrite_args->obj == obj_saved);
+                } else {
+                    rewrite_args->obj = rewrite_args->rewriter->loadConst((intptr_t)base, Location::any());
+                    // We are passing a constant object, and objects are not allowed to change shape
+                    // (at least the kind of "shape" that Box::getattr is referring to)
+                    rewrite_args->obj_shape_guarded = true;
+                }
             }
             val = base->getattr(attr, rewrite_args);
-            assert(rewrite_args->out_success);
+
+            if (rewrite_args && !rewrite_args->out_success)
+                rewrite_args = NULL;
+
             if (val)
                 return val;
         }
 
-        assert(rewrite_args->out_success);
-        assert(!rewrite_args->out_rtn);
-        rewrite_args->out_return_convention = GetattrRewriteArgs::NO_RETURN;
+        if (rewrite_args) {
+            assert(rewrite_args->out_success);
+            assert(!rewrite_args->out_rtn);
+            rewrite_args->out_return_convention = GetattrRewriteArgs::NO_RETURN;
+        }
         return NULL;
     } else {
         assert(attr->interned_state != SSTATE_NOT_INTERNED);

--- a/src/runtime/types.cpp
+++ b/src/runtime/types.cpp
@@ -1406,7 +1406,7 @@ static void typeSubSetDict(Box* obj, Box* val, void* context) {
     }
 
     if (obj->cls->instancesHaveHCAttrs()) {
-        RELEASE_ASSERT(val->cls == dict_cls || val->cls == attrwrapper_cls, "");
+        RELEASE_ASSERT(PyDict_Check(val) || val->cls == attrwrapper_cls, "%s", val->cls->tp_name);
 
         auto new_attr_list
             = (HCAttrs::AttrList*)gc_alloc(sizeof(HCAttrs::AttrList) + sizeof(Box*), gc::GCKind::PRECISE);
@@ -1421,6 +1421,11 @@ static void typeSubSetDict(Box* obj, Box* val, void* context) {
 
     // This should have thrown an exception rather than get here:
     abort();
+}
+
+extern "C" void PyType_SetDict(PyTypeObject* type, PyObject* dict) {
+    typeSubSetDict(type, dict, NULL);
+    type->tp_dict = dict;
 }
 
 Box* dict_descr = NULL;

--- a/test/tests/ctypes_test.py
+++ b/test/tests/ctypes_test.py
@@ -1,0 +1,7 @@
+from ctypes import *
+s = "tmp"
+ap = create_string_buffer(s)
+
+print type(ap)
+print type(c_void_p.from_param(ap))
+print type(cast(ap, c_char_p))


### PR DESCRIPTION
ctypes directly assigns to tp_dict and expects the changes to get picked up.
For now add a new API call that will have this effect, but will also update
our internal bookkeeping (setting the object to dict-backed and the new dict
as the backing).
